### PR TITLE
Methods having documentation comments

### DIFF
--- a/src/Faker/Caching/PropertyHelper.cs
+++ b/src/Faker/Caching/PropertyHelper.cs
@@ -14,11 +14,11 @@ namespace Faker.Caching
 	internal static class PropertyHelper
 	{
 		/// <summary>
-		///   Extracts the PropertyInfo for the member selector
+		///   Extracts the Property Information for the member selector
 		/// </summary>
 		/// <typeparam name="TValue">Type returned from the selector</typeparam>
-		/// <param name="selector">The lambda expression to extract property of</param>
-		/// <returns>The property info</returns>
+		/// <param name="selector">The lambda expression to extract property from</param>
+		/// <returns>The property information</returns>
 		public static PropertyInfo GetProperty<TValue>(
 			Expression<Func<TValue>> selector)
 		{

--- a/src/Faker/Caching/PropertyHelper.cs
+++ b/src/Faker/Caching/PropertyHelper.cs
@@ -13,6 +13,12 @@ namespace Faker.Caching
 	/// </remarks>
 	internal static class PropertyHelper
 	{
+		/// <summary>
+		///   Extracts the PropertyInfo for the member selector
+		/// </summary>
+		/// <typeparam name="TValue">Type returned from the selector</typeparam>
+		/// <param name="selector">The lambda expression to extract property of</param>
+		/// <returns>The property info</returns>
 		public static PropertyInfo GetProperty<TValue>(
 			Expression<Func<TValue>> selector)
 		{

--- a/src/Faker/Caching/ResourceCollectionCacher.cs
+++ b/src/Faker/Caching/ResourceCollectionCacher.cs
@@ -17,6 +17,16 @@ namespace Faker.Caching
 		private static object lockObj = new object();
 		private static Dictionary<string, string[]> cache = new Dictionary<string, string[]>();
 
+		/// <summary>
+		///   Gets the cached array (with O(1) complexity) in cache-hit case. In cache-miss case,
+		///   invokes the property, splits, caches, and returns the array (with O(n) complexity).
+		/// </summary>
+		/// <param name="p">The property returning the array</param>
+		/// <returns>The (possibly cached) array</returns>
+		/// <remarks>
+		///   The cache is indexed by the class holding the property, the property name and the
+		///   current UI culture name.
+		/// </remarks>
 		internal static string[] GetArray(PropertyInfo p)
 		{
 			var invokingClassName = p.DeclaringType.FullName;


### PR DESCRIPTION
Methods ResourceCollectionCacher.GetArray() and PropertyHelper.GetProperty() have documentation comments (Issue #39).
